### PR TITLE
Only use sh layer when needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var fs = require('fs')
 var readFile = require('read-file-live')
 var respawn = require('respawn')
 var chalk = require('chalk')
+var bashParse = require('shell-quote').parse
 
 var BIN_SH = process.platform === 'android' ? '/system/bin/sh' : '/bin/sh'
 var CMD_EXE = process.env.comspec || 'cmd.exe'
@@ -122,6 +123,8 @@ function prefix (pid) {
 }
 
 function spawn (cmd) {
+  var args = bashParse(cmd)
+  if (args.every(item => typeof item === 'string')) return respawn(args, {maxRestarts: Infinity})
   if (process.platform !== 'win32') return respawn([BIN_SH, '-c', cmd], {maxRestarts: Infinity})
   return respawn([CMD_EXE, '/d', '/s', '/c', '"' + cmd + '"'], {maxRestarts: Infinity, windowsVerbatimArguments: true})
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "read-file-live": "^1.0.1",
-    "respawn": "^2.4.1"
+    "respawn": "^2.4.1",
+    "shell-quote": "^1.6.1"
   },
   "devDependencies": {
     "standard": "^8.6.0"


### PR DESCRIPTION
Using shell-quote, we can know if the string is as plain command or has bash operators in it.  In case it's plain, there is no need to insert the parent sh process.